### PR TITLE
feat: pass config `defaultBranchName` to gitinfo if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ Prints a string formatted according to the given [moment format](http://momentjs
 Generates:
 
 ```markdown
-1561166482
+1561166577
 2019
 ```
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ Prints a string formatted according to the given [moment format](http://momentjs
 Generates:
 
 ```markdown
-1560895526
+1561166482
 2019
 ```
 

--- a/src/helpers/gitinfo.js
+++ b/src/helpers/gitinfo.js
@@ -5,7 +5,8 @@ const createGitinfo = require('gitinfo');
 helper.compile = (config, context) => {
   const parserConfig = context.gitdown.getConfig().gitinfo;
   const gitinfo = createGitinfo({
-    gitPath: parserConfig.gitPath
+    gitPath: parserConfig.gitPath,
+    ...parserConfig.defaultBranchName && {defaultBranchName: parserConfig.defaultBranchName}
   });
 
   const methodMap = {

--- a/tests/dummy_git_untracked_head/HEAD
+++ b/tests/dummy_git_untracked_head/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/some-untracked-branch

--- a/tests/dummy_git_untracked_head/config
+++ b/tests/dummy_git_untracked_head/config
@@ -1,0 +1,13 @@
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	ignorecase = true
+	precomposeunicode = true
+[remote "origin"]
+	url = git@github.com:foo/bar.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "master"]
+	remote = origin
+	merge = refs/heads/master

--- a/tests/dummy_git_untracked_head/objects/.gitignore
+++ b/tests/dummy_git_untracked_head/objects/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/dummy_git_untracked_head/refs/.gitignore
+++ b/tests/dummy_git_untracked_head/refs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/gitdown.js
+++ b/tests/gitdown.js
@@ -108,6 +108,20 @@ describe('Gitdown.read()', () => {
 
       expect(response).to.equal('abc');
     });
+    it('does not fail when HEAD is untracked', async () => {
+      const gitdown = Gitdown.read('{"gitdown": "gitinfo", "name": "name"}');
+
+      gitdown.setConfig({
+        gitinfo: {
+          defaultBranchName: 'master',
+          gitPath: path.resolve(__dirname, './dummy_git_untracked_head/')
+        }
+      });
+
+      const response = await gitdown.get();
+
+      expect(response).to.equal('bar');
+    });
   });
   describe('.writeFile()', () => {
     it('writes the output of .get() to a file', async () => {


### PR DESCRIPTION
Unblocks https://github.com/gajus/eslint-plugin-jsdoc/pull/241.

Without setting `defaultBranchName` to `master`, calling `gitdown` in a non `master` branch fails.

The gitinfo config defaultBranchName is defined here: https://github.com/gajus/gitinfo/blob/24dde226da187a2547a2378f669444f47f99eb78/src/gitinfo.js#L18