### PR TITLE
build: fix npm script `test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "build": "babel ./src --out-dir ./dist --copy-files",
     "create-readme": "babel-node ./src/bin/index.js ./.README/README.md --output-file ./README.md",
     "lint": "eslint ./src ./tests",
-    "test": "mocha ./tests/**/*.js --require @babel/register"
+    "test": "mocha \"./tests/**/*.js\" --require @babel/register"
   },
   "version": "2.5.2"
 }


### PR DESCRIPTION
Glob path in `mocha ./tests/**/*.js` must be quoted as `mocha "./tests/**/*.js"`, otherwise it will be expanded by shell, which will not include `tests/thing.js`.