### PR TITLE
Npmjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ coverage
 dist
 node_modules
 package-lock.json
+pnpm-lock.yaml
 *.log
 .*
 !.babelrc.json

--- a/src/gitdown.js
+++ b/src/gitdown.js
@@ -321,7 +321,9 @@ Gitdown.nestHeadingIds = (inputMarkdown) => {
 
     // <code>test</code>
 
-    return '<a name="⊂⊂⊂H:' + articles.length + '⊃⊃⊃"></a>\n' + _.repeat('#', normalizedLevel) + ' ' + normalizedName;
+    return `<a name="user-content-⊂⊂⊂H:${articles.length}⊃⊃⊃"></a>
+<a name="⊂⊂⊂H:${articles.length}⊃⊃⊃"></a>
+${_.repeat('#', normalizedLevel)} ${normalizedName}`;
   });
 
   outputMarkdown = outputMarkdown.replace(/^⊂⊂⊂C:(\d+)⊃⊃⊃/gm, () => {
@@ -331,7 +333,7 @@ Gitdown.nestHeadingIds = (inputMarkdown) => {
   const tree = contents.nestIds(MarkdownContents.tree(articles));
 
   Gitdown.nestHeadingIds.iterateTree(tree, (index, article) => {
-    outputMarkdown = outputMarkdown.replace('⊂⊂⊂H:' + index + '⊃⊃⊃', article.id);
+    outputMarkdown = outputMarkdown.replace(new RegExp('⊂⊂⊂H:' + index + '⊃⊃⊃', 'g'), article.id);
   });
 
   return outputMarkdown;

--- a/src/gitdown.js
+++ b/src/gitdown.js
@@ -8,9 +8,9 @@ const _ = require('lodash');
 const MarkdownContents = require('markdown-contents');
 const marked = require('marked');
 const StackTrace = require('stack-trace');
-const contents = require('./helpers/contents.js');
-const gitinfo = require('./helpers/gitinfo.js');
-const Parser = require('./parser.js');
+const contents = require('./helpers/contents');
+const gitinfo = require('./helpers/gitinfo');
+const Parser = require('./parser');
 
 /**
  * @param {string} input Gitdown flavored markdown.

--- a/src/gitdown.js
+++ b/src/gitdown.js
@@ -39,6 +39,8 @@ Gitdown.read = (input) => {
       markdown = Gitdown.nestHeadingIds(markdown);
     }
 
+    markdown = Gitdown.prefixRelativeUrls(markdown);
+
     await gitdown.resolveURLs(markdown);
 
     return markdown.replace(/<!--\sgitdown:\s(:?off|on)\s-->/g, '');
@@ -258,6 +260,19 @@ Gitdown.readFile = (fileName) => {
   });
 
   return gitdown;
+};
+
+/**
+ * Prefixes "user-content-" to each Markdown internal link.
+ *
+ * @private
+ * @param {string} inputMarkdown
+ * @returns {string}
+ */
+Gitdown.prefixRelativeUrls = (inputMarkdown) => {
+  return inputMarkdown.replace(/\[(.*?)]\(#(.*?)\)/gm, (match, text, anchor) => {
+    return `[${text}](#user-content-${anchor})`;
+  });
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-const Gitdown = require('./gitdown.js');
+const Gitdown = require('./gitdown');
 
-Gitdown.Parser = require('./parser.js');
+Gitdown.Parser = require('./parser');
 
 module.exports = Gitdown;

--- a/src/parser.js
+++ b/src/parser.js
@@ -2,7 +2,7 @@ const Path = require('path');
 const Promise = require('bluebird');
 const glob = require('glob');
 const _ = require('lodash');
-const Locator = require('./locator.js');
+const Locator = require('./locator');
 
 /**
  * Parser is responsible for matching all of the instances of the Gitdown JSON and invoking

--- a/tests/gitdown.js
+++ b/tests/gitdown.js
@@ -29,6 +29,12 @@ describe('Gitdown', () => {
     });
   });
 
+  describe('prefixRelativeUrls', () => {
+    it('replaces relative links', () => {
+      expect(Gitdown.prefixRelativeUrls('A [relative](#link) test')).to.equal('A [relative](#user-content-link) test');
+    });
+  });
+
   describe('.nestHeadingIds()', () => {
     it('replaces heading markup with HTML', () => {
       expect(

--- a/tests/gitdown.js
+++ b/tests/gitdown.js
@@ -31,10 +31,18 @@ describe('Gitdown', () => {
 
   describe('.nestHeadingIds()', () => {
     it('replaces heading markup with HTML', () => {
-      expect(Gitdown.nestHeadingIds('# Foo\n# Bar')).to.equal('<a name="foo"></a>\n# Foo\n<a name="bar"></a>\n# Bar');
+      expect(
+        Gitdown.nestHeadingIds('# Foo\n# Bar'),
+      ).to.equal(
+        '<a name="user-content-foo"></a>\n<a name="foo"></a>\n# Foo\n<a name="user-content-bar"></a>\n<a name="bar"></a>\n# Bar',
+      );
     });
     it('nests heading ids', () => {
-      expect(Gitdown.nestHeadingIds('# Foo\n## Bar')).to.equal('<a name="foo"></a>\n# Foo\n<a name="foo-bar"></a>\n## Bar');
+      expect(
+        Gitdown.nestHeadingIds('# Foo\n## Bar'),
+      ).to.equal(
+        '<a name="user-content-foo"></a>\n<a name="foo"></a>\n# Foo\n<a name="user-content-foo-bar"></a>\n<a name="foo-bar"></a>\n## Bar',
+      );
     });
   });
   describe('.nestHeadingIds.iterateTree()', () => {


### PR DESCRIPTION
- fix: prefix relative URLs with "user-content-" for npmjs compatibility

As this now prefixes relative URL links, the second commit in this PR also adds its own "user-content-" anchors. While this is not strictly necessarily for GitHub or npmjs.com, it might be safer to ensure that the targeted anchors continue to exist for any environments which do not add the "user-content-" prefix. Let me know if you'd like me to remove this latter commit.

Fixes #63