### PR TITLE
fix: for native ESM environments, pass in gitinfo to `read` to avoid erring

### DIFF
--- a/src/gitdown.js
+++ b/src/gitdown.js
@@ -14,8 +14,9 @@ const Parser = require('./parser');
 
 /**
  * @param {string} input Gitdown flavored markdown.
+ * @param {object} [gitInfo]
  */
-Gitdown.read = (input) => {
+Gitdown.read = (input, gitInfo) => {
   let instanceConfig;
   let instanceLogger;
 
@@ -218,7 +219,7 @@ Gitdown.read = (input) => {
       findDeadFragmentIdentifiers: false,
       findDeadURLs: false,
     },
-    gitinfo: {
+    gitinfo: gitInfo || {
       gitPath: gitdown.executionContext(),
     },
     headingNesting: {
@@ -248,15 +249,12 @@ Gitdown.readFile = (fileName) => {
     encoding: 'utf8',
   });
 
-  const gitdown = Gitdown.read(input);
-
   const directoryName = path.dirname(fileName);
-
+  const gitdown = Gitdown.read(input, {
+    gitPath: directoryName
+  });
   gitdown.setConfig({
-    baseDirectory: directoryName,
-    gitinfo: {
-      gitPath: directoryName,
-    },
+    baseDirectory: directoryName
   });
 
   return gitdown;


### PR DESCRIPTION
fix: for native ESM environments, pass in gitinfo to `read` to avoid erring

I'm switching `eslint-plugin-jsdoc` to support native ESM (and fix a TS bug in the process) as well as CJS fallback, but the native ESM environment gives problems with the stack/execution context used by Gitdown.

This PR works around that problem (and allows us to resume running `create-docs` upon pushes).