### PR TITLE
fix: disable remote url resolving

### DIFF
--- a/src/gitdown.js
+++ b/src/gitdown.js
@@ -51,7 +51,7 @@ Gitdown.read = async (input, gitInfo) => {
 
     markdown = Gitdown.prefixRelativeUrls(markdown);
 
-    await gitdown.resolveURLs(markdown);
+    // await gitdown.resolveURLs(markdown); // Disabling until may remove
 
     return markdown.replaceAll(/<!--\sgitdown:\s(:?off|on)\s-->/gu, '');
   };

--- a/tests/gitdown.js
+++ b/tests/gitdown.js
@@ -218,7 +218,7 @@ describe('Gitdown.read()', () => {
       expect(defaultConfiguration).to.equal(gitdown.config);
     });
   });
-  describe('.resolveURLs()', () => {
+  describe.skip('.resolveURLs()', () => {
     let gitdown;
     let logger;
     let nocks;


### PR DESCRIPTION
This is just a temporary hack to get things working (until such time as the functionality can be removed or adapted).